### PR TITLE
Add files via upload

### DIFF
--- a/kartoza_spike_removal_v01.py
+++ b/kartoza_spike_removal_v01.py
@@ -3,14 +3,12 @@ import sys
 import datetime
 import time
 import ntpath
-import statistics
 
-from osgeo import gdal
 from osgeo import ogr
 
-POLYGONS = "D:/Kartoza/additional/multipolygon/test5.gpkg"
+POLYGONS = "D:/Kartoza/additional/multipolygon/test8.gpkg"
 OUTPUT = "D:/Kartoza/output/"
-OUTPUT_NAME = "test5_spikes_removed.gpkg"
+OUTPUT_NAME = "test8_spikes_removed.gpkg"
 DISTANCE = 10  # Distance in meters
 Z_FACTOR = 0.00001  # 1 for projected, 0.00001 for geographic
 OVERWRITE = True
@@ -66,6 +64,18 @@ def perform_checks():
         write_message("ERROR: Output directory not found: " + str(OUTPUT))
         stop_script = True
 
+    if not check_extension(OUTPUT_NAME, ["gpkg"]):
+        write_message("ERROR: Output file name has to be geopackage format (*.gpkg).")
+        stop_script = True
+
+    output_file = OUTPUT + OUTPUT_NAME
+    if os.path.exists(output_file):
+        if OVERWRITE:
+            os.remove(output_file)
+        else:
+            write_message("ERROR: Output file already exists: " + str(output_file))
+            stop_script = True
+
     return stop_script
 
 
@@ -86,8 +96,6 @@ def polygon_spike_removal(vector_file):
     file = ogr.Open(vector_file)
     vector_layers = file.GetLayer(0)
     layer_cnt = len(vector_layers)
-    spatial_ref = vector_layers.GetSpatialRef()
-    layer_extent = vector_layers.GetExtent()
 
     # Checks if the vector layer consist of features/polygons
     if layer_cnt > 0:
@@ -98,17 +106,13 @@ def polygon_spike_removal(vector_file):
 
         # Buffering
         data = ogr.GetDriverByName("GPKG").CreateDataSource(temp_dir + "buffer.gpkg")
-        lyr = data.CreateLayer('polygon2d', geom_type=ogr.wkbPolygon)
-    
+        lyr = data.CreateLayer('polygon', geom_type=ogr.wkbPolygon)
+
         # Points/vertices
         data_p = ogr.GetDriverByName("GPKG").CreateDataSource(temp_dir + "vertices.gpkg")
         lyr_p = data_p.CreateLayer('point', geom_type=ogr.wkbPoint)
-    
-        # Final vector file with no spikes
-        data_f = ogr.GetDriverByName("GPKG").CreateDataSource(OUTPUT + OUTPUT_NAME)
-        lyr_f = data_f.CreateLayer('polygon2d', geom_type=ogr.wkbPolygon)
-    
-        point_geom = ogr.Geometry(ogr.wkbPoint)
+
+        output_file = OUTPUT + OUTPUT_NAME
         # Performs spike removal on each polygon
         for feat in vector_layers:
             geom = feat.GetGeometryRef()
@@ -118,10 +122,21 @@ def polygon_spike_removal(vector_file):
                 input_geom_type = str(geom.GetGeometryName()).lower()
                 write_message("Geometry type: " + str(input_geom_type))
 
+                # Single-part polygons
                 if input_geom_type == "polygon" or input_geom_type == "curvepolygon":
-                    write_message("Singlepart polygons.")
+                    write_message("Singlepart polygons: " + input_geom_type)
+
+                    # Creates the output file if it does not exist
+                    if not os.path.exists(output_file):
+                        # Final vector file with no spikes
+                        data_f = ogr.GetDriverByName("GPKG").CreateDataSource(output_file)
+                        if input_geom_type == "polygon":
+                            lyr_f = data_f.CreateLayer(input_geom_type, geom_type=ogr.wkbPolygon)
+                        else:
+                            lyr_f = data_f.CreateLayer(input_geom_type, geom_type=ogr.wkbCurvePolygon)
+
                     ring = geom.GetGeometryRef(0)  # Polygon boundary
-    
+
                     # Creates a negative buffer to remove slivers from outlier vertices
                     geom_buf = geom.Buffer(-1 * DISTANCE * Z_FACTOR)
                     new_feat = ogr.Feature(lyr.GetLayerDefn())
@@ -133,6 +148,7 @@ def polygon_spike_removal(vector_file):
 
                     ring_spike_removed = ogr.Geometry(ogr.wkbLinearRing)
                     removed_point_count = 0
+                    point_geom = ogr.Geometry(ogr.wkbPoint)
                     # Checks each of the polygon vertices
                     for i in range(0, cnt):
                         point = ring.GetPoint(i)
@@ -162,51 +178,75 @@ def polygon_spike_removal(vector_file):
                     new_poly = ogr.Feature(lyr_f.GetLayerDefn())
                     new_poly.SetGeometry(ogr.CreateGeometryFromWkt(str(poly_spike_removed)))
                     lyr_f.CreateFeature(new_poly)
+                # Multi-part polygons
                 elif input_geom_type == "multipolygon" or input_geom_type == "multisurface":
-                    write_message("Multipart polygons.")
-                    multi_polygons = geom.GetGeometryRef(0)  # Polygon boundary
-                    ring = multi_polygons.GetGeometryRef(0)
+                    write_message("Multipart polygons: " + input_geom_type)
 
-                    # Creates a negative buffer to remove slivers from outlier vertices
-                    geom_buf = geom.Buffer(-1 * DISTANCE * Z_FACTOR)
-                    new_feat = ogr.Feature(lyr.GetLayerDefn())
-                    new_feat.SetGeometry(ogr.CreateGeometryFromWkt(str(geom_buf)))
-                    lyr.CreateFeature(new_feat)
+                    if not os.path.exists(output_file):
+                        # Final vector file with no spikes
+                        data_f = ogr.GetDriverByName("GPKG").CreateDataSource(output_file)
+                        if input_geom_type == "multipolygon":
+                            lyr_f = data_f.CreateLayer(input_geom_type, geom_type=ogr.wkbMultiPolygon)
+                        else:
+                            lyr_f = data_f.CreateLayer(input_geom_type, geom_type=ogr.wkbMultiSurface)
 
-                    cnt = ring.GetPointCount()
-                    write_message("Vertice count: " + str(cnt))
+                    multi_poly_cnt = geom.GetGeometryCount()
+                    write_message("Multi-polygon count: " + str(multi_poly_cnt))
 
-                    ring_spike_removed = ogr.Geometry(ogr.wkbLinearRing)
-                    removed_point_count = 0
-                    # Checks each of the polygon vertices
-                    for i in range(0, cnt):
-                        point = ring.GetPoint(i)
-                        point_geom.AddPoint(point[0], point[1])
+                    if input_geom_type == "multipolygon":
+                        multipoly_geom = ogr.Geometry(ogr.wkbMultiPolygon)
+                    else:
+                        multipoly_geom = ogr.Geometry(ogr.wkbMultiSurface)
 
-                        new_point = ogr.Feature(lyr_p.GetLayerDefn())
-                        new_point.SetGeometry(ogr.CreateGeometryFromWkt(str(point_geom)))
+                    # Loops through each polygon of the multipolygon feature
+                    for multi_polygon in geom:
+                        ring = multi_polygon.GetGeometryRef(0)  # Polygon boundary
 
-                        # Converts the distance based on the Z_FACTOR variable
-                        distance = (geom_buf.Distance(point_geom)) / Z_FACTOR
+                        # Creates a negative buffer to remove slivers from outlier vertices
+                        geom_buf = geom.Buffer(-1 * DISTANCE * Z_FACTOR)
+                        new_feat = ogr.Feature(lyr.GetLayerDefn())
+                        new_feat.SetGeometry(ogr.CreateGeometryFromWkt(str(geom_buf)))
+                        lyr.CreateFeature(new_feat)
 
-                        # If the point is a large distance from the negative buffer polygons, its likely a spike
-                        if distance < DISTANCE * 10:  # Adds the point if its not a spike
-                            lyr_p.CreateFeature(new_point)
-                            ring_spike_removed.AddPoint(point[0], point[1])
-                        else:  # Remove the point
-                            write_message("Spike polygon vertice found (" + str(distance) + "m from polygon.)")
-                            removed_point_count = removed_point_count + 1
+                        cnt = ring.GetPointCount()
+                        write_message("Vertice count: " + str(cnt))
+    
+                        ring_spike_removed = ogr.Geometry(ogr.wkbLinearRing)
+                        removed_point_count = 0
+                        point_geom = ogr.Geometry(ogr.wkbPoint)
+                        # Checks each of the polygon vertices
+                        for i in range(0, cnt):
+                            point = ring.GetPoint(i)
+                            point_geom.AddPoint(point[0], point[1])
 
-                    write_message(str(removed_point_count) + " vertice(s) removed from the polygon.")
+                            new_point = ogr.Feature(lyr_p.GetLayerDefn())
+                            new_point.SetGeometry(ogr.CreateGeometryFromWkt(str(point_geom)))
 
-                    # Convert the remaining vertices to a polygon boundary
-                    poly_spike_removed = ogr.Geometry(ogr.wkbPolygon)
-                    poly_spike_removed.AddGeometry(ring_spike_removed)
+                            # Converts the distance based on the Z_FACTOR value
+                            distance = (geom_buf.Distance(point_geom)) / Z_FACTOR
 
-                    # Creates the spike removed polygon and adds it to the vector file
+                            # If the point is a large distance from the negative buffer polygons, its likely a spike
+                            if distance < DISTANCE * 10:  # Adds the point if its not a spike
+                                lyr_p.CreateFeature(new_point)
+                                ring_spike_removed.AddPoint(point[0], point[1])
+                            else:  # Remove the point
+                                write_message("Spike polygon vertice found (" + str(distance) + "m from polygon).")
+                                removed_point_count = removed_point_count + 1
+
+                        write_message(str(removed_point_count) + " vertice(s) removed from the polygon.")
+
+                        # Convert the remaining vertices to a polygon boundary
+                        poly_spike_removed = ogr.Geometry(ogr.wkbPolygon)
+                        poly_spike_removed.AddGeometry(ring_spike_removed)
+
+                        # Adds the spike removed polygon to the multi-polygon geometry
+                        multipoly_geom.AddGeometry(poly_spike_removed)
+
+                    # Creates the spike removed multi-polygon and adds it to the vector file
                     new_poly = ogr.Feature(lyr_f.GetLayerDefn())
-                    new_poly.SetGeometry(ogr.CreateGeometryFromWkt(str(poly_spike_removed)))
+                    new_poly.SetGeometry(ogr.CreateGeometryFromWkt(str(multipoly_geom)))
                     lyr_f.CreateFeature(new_poly)
+                # The provided file is of incorrect geometry type
                 else:
                     write_message("ERROR: Incorrect geometry type: " + str(input_geom_type) +
                                   ". Should be: polygon, multipolygon, curve polygon or multisurface polygon.")


### PR DESCRIPTION
If a multipolygon or multisurface polygon feature consists of more than one polygon (multipart), the output feature (spikes removed) is now stored correctly as a single, multipart feature and not several separate polygon features. Fixed an issue where curvepolygons, multipolygon and multisurface polygons where declared as polygon. Now more accurately shows the geometry type of the file. Additional check added which only allows geopackage format (gpkg) as the output filename format.